### PR TITLE
makefile: Fix undefined reference on Alpine Linux

### DIFF
--- a/makefile
+++ b/makefile
@@ -77,13 +77,13 @@ $(TESTDIR)%.o: $(TESTDIR)%.c
 	$(CC) -c $(CPPFLAGS) $(CFLAGS) $< -o $@
 
 $(TESTDIR)teststatic: $(testobjects)
-	$(CC) -static $(TESTLDFLAGS) $^ $(TESTLDLIBS) -lm -o $@
+	$(CC) -static $(TESTLDFLAGS) $^ $(TESTLDLIBS) -lm $(staticobjects) -o $@
 
 $(TESTDIR)testshared: $(testobjects)
-		$(CC) $(TESTLDFLAGS) $^ $(TESTLDLIBS) -o $@
+		$(CC) $(TESTLDFLAGS) $^ $(TESTLDLIBS) $(sharedobjects) -o $@
 
 $(TESTDIR)test: $(testobjects)
-		$(CC) $(TESTLDFLAGS) $^ $(TESTLDLIB) $(LDLIBS) -o $@
+		$(CC) $(TESTLDFLAGS) $^ $(TESTLDLIB) $(LDLIBS) $(sharedobjects) -o $@
 
 testobjects: shared static
 


### PR DESCRIPTION
https://stackoverflow.com/questions/12272864/linker-error-on-linux-undefined-reference-tohttps://stackoverflow.com/questions/12272864/linker-error-on-linux-undefined-reference-to

Interestingly enough, it compiles well in Ubuntu even without this patch.

Thank you @yparitcher for this library!